### PR TITLE
Update Autodock Vina hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## requirements
 
-- [AutoDock Vina](https://anaconda.org/bioconda/autodock-vina)
+- [AutoDock Vina](https://autodock-vina.readthedocs.io/en/latest/)
 - [ADFR](https://ccsb.scripps.edu/projects/docking/)
 - [pymol](https://pymol.org/2/)
 - [rdkit](http://rdkit.org/)


### PR DESCRIPTION
I found that the AutoDock Vina in this README to be incorrect. AutoDock Vina in here suppose to be installed from [ccsb-scripps](https://autodock-vina.readthedocs.io/en/latest/installation.html) channel rather than Bioconda. The one from Bioconda is the old version (1.1), while from ccsb-scripps is 1.2 which support Python binding.